### PR TITLE
BugFix for Hero Banner and Footer

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/footer/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/footer/_cq_dialog/.content.xml
@@ -53,14 +53,14 @@
                                                 <items jcr:primaryType="nt:unstructured">
                                                     <socialicon
                                                         jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
                                                         fieldDescription="Image of the social icon"
                                                         fieldLabel="Social Icon"
                                                         name="./socialIcon"
                                                         rootPath="/content/dam/taylorsuniversity"/>
                                                     <sociallink
                                                         jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
                                                         fieldDescription="Link of the social icon. It will open in a new window if external link."
                                                         fieldLabel="Social Link"
                                                         name="./socialLink"

--- a/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/herobanner/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/herobanner/_cq_dialog/.content.xml
@@ -72,7 +72,7 @@
                                         fieldDescription="Path of the red link (1st link)"
                                         fieldLabel="Red Link Path"
                                         name="./redLinkPath"
-                                        rootPath="/content"/>
+                                        rootPath="/content/taylorsuniversity"/>
                                     <whitelinktitle
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
@@ -85,7 +85,7 @@
                                         fieldDescription="Path of the white link (2nd link)"
                                         fieldLabel="White Link Path"
                                         name="./whiteLinkPath"
-                                        rootPath="/content"/>
+                                        rootPath="/content/taylorsuniversity"/>
                                 </items>
                             </title>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/herobanner/herobanner.html
+++ b/ui.apps/src/main/content/jcr_root/apps/taylorsuniversity/components/content/herobanner/herobanner.html
@@ -3,8 +3,7 @@
 </sly>
 
 <sly data-sly-use.hb="com.taylorsuniversity.models.HeroBannerModel">
-
-<!--Conditional HTML snippet for video-->
+<!--/* Conditional HTML snippet for videos */-->
 <sly data-sly-test="${properties.desktopReference && hb.damType=='video'}">  
 <div class="cover-container banner-video red-blend no-hover-mobile position-relative"
 	style="background-image: url('${properties.imageReference @ context='styleString'}');">
@@ -15,45 +14,42 @@
 	</video>
 
 	<div class="hearo-banner-content t-m text-white">
-     <!--Common HTML Snippet for both image and video-->   
+        <!--/* Common HTML Snippet for both image and video */-->  
 		<h1 data-sly-test="${properties.title}">${properties.title}</h1>
 		<div class="d-flex flex-column">
 			<a data-sly-test.redLinkPath="${properties.redLinkPath}" class="btn btn-simple btn-red btn-standard-w  mb-3" 
                data-sly-use.linkHelper="${'com.taylorsuniversity.models.SightlyUtilsModel' @ linkTarget=redLinkPath}" 
-               href="${linkHelper.link}">
+               href="${linkHelper.link}" target="${linkHelper.titleLinkType=='true'? '_self' : '_blank'}">
                 ${properties.redLinkTitle}<i class="t-icon-right white"></i>
 			</a>
             <a data-sly-test.whiteLinkPath="${properties.whiteLinkPath}" class="btn btn-simple btn-clear btn-standard-w white-bordered" 
                data-sly-use.linkHelper="${'com.taylorsuniversity.models.SightlyUtilsModel' @ linkTarget=whiteLinkPath}" 
-               href="${linkHelper.link}">
+               href="${linkHelper.link}" target="${linkHelper.titleLinkType=='true'? '_self' : '_blank'}">
                 ${properties.whiteLinkTitle}<i class="t-icon-right white"></i>
             </a>
 		</div>
 	</div>
 </div>
 </sly>
-    
-<!--Conditional HTML snippet for image-->  
+<!--/* Conditional HTML snippet for image */-->
 <sly data-sly-test="${properties.desktopReference && hb.damType=='image'}">  
     <div class="cover-container d-flex align-items-end t-p  red-blend-no-hover" style="background-image: url('${properties.desktopReference @ context='styleString'}');">
         <div class="hearo-banner-content align-self-end text-white">
-             <!--Common HTML Snippet for both image and video-->   
+            <!--/* Common HTML Snippet for both image and video */-->
             <h1 data-sly-test="${properties.title}">${properties.title}</h1>
             <div class="d-flex flex-column">
                 <a data-sly-test.redLinkPath="${properties.redLinkPath}" class="btn btn-simple btn-red btn-standard-w  mb-3" 
                    data-sly-use.linkHelper="${'com.taylorsuniversity.models.SightlyUtilsModel' @ linkTarget=redLinkPath}" 
-                   href="${linkHelper.link}">
+                   href="${linkHelper.link}" target="${linkHelper.titleLinkType=='true'? '_self' : '_blank'}">
                     ${properties.redLinkTitle}<i class="t-icon-right white"></i>
                 </a>
                 <a data-sly-test.whiteLinkPath="${properties.whiteLinkPath}" class="btn btn-simple btn-clear btn-standard-w white-bordered" 
                    data-sly-use.linkHelper="${'com.taylorsuniversity.models.SightlyUtilsModel' @ linkTarget=whiteLinkPath}" 
-                   href="${linkHelper.link}">
+                   href="${linkHelper.link}" target="${linkHelper.titleLinkType=='true'? '_self' : '_blank'}">
                     ${properties.whiteLinkTitle}<i class="t-icon-right white"></i>
                 </a>
             </div>
 		</div>
 	</div>
 </sly>
-
-
 </sly>


### PR DESCRIPTION
Footer: Reverted to Pathbrowser from Pathfield: as authored values were not getting persisted

Hero Banner: External links now open in new window.  Changed to sightly comments instead.